### PR TITLE
WIP: TLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 axum = "0.7.9"
+axum-server = {version = "0.7.1", features = ["tls-rustls"]}
 tokio = { version = "1.42.0", features = ["full"]}
 tower-http = {version = "0.6.2", features = ["fs", "trace"]}

--- a/README.md
+++ b/README.md
@@ -50,11 +50,16 @@ To get started with Binary Dealer, follow these steps:
 2. Build the project:
    ```bash
    cargo build --release
-   ```
+ 
+3. To enable TLS with a self-signed certificate and then return to the project's root folder:
+   ```bash
+   cd self_signed_certs
+   openssl req -newkey rsa:4096  -x509  -sha512  -days 500 -nodes -out cert.pem -keyout key.pem
+   cd ..
 
-3. Run the server:
+4. Run the server:
    ```bash
    cargo run --release
    ```
 
-4. Place your precompiled binaries in the specified directory for access.
+5. Place your precompiled binaries in the specified directory for access.


### PR DESCRIPTION
Aims to fix #9 

To generate self-signed keys, open /self_signed_certs/ in a terminal and use
`openssl req -newkey rsa:4096  -x509  -sha512  -days 500 -nodes -out cert.pem -keyout key.pem`

Running locally, a text-file is retrieved with a browser navigating to https://127.0.0.1:3953/getme and using `wget --https-only --no-check-certificate https://127.0.0.1:3953/getme`

No testing with `nc` to this point.