### PR TITLE
Update axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.7.9"
+axum = "0.8.1"
 axum-server = {version = "0.7.1", features = ["tls-rustls"]}
 tokio = { version = "1.42.0", features = ["full"]}
 tower-http = {version = "0.6.2", features = ["fs", "trace"]}

--- a/README.md
+++ b/README.md
@@ -2,40 +2,30 @@
 
 ## Overview
 
-**Binary Dealer** is a Rust-based tool designed to streamline the distribution and managemen
-t of static binary files across multiple projects. With an emphasis on version control and e
-ase of access, Binary Dealer aims to facilitate the seamless retrieval and deployment of bin
-aries, while automating the build process as it evolves.
+**Binary Dealer** is a Rust-based tool designed to streamline the distribution and management of static binary files across multiple projects. With an emphasis on version control and e
+ase of access, Binary Dealer aims to facilitate the seamless retrieval and deployment of binaries, while automating the build process as it evolves.
 
 ## Planned Features
 
-- **Static Binary Serving**: Initially, the server will serve static binary files, making it
- easy to access precompiled binaries for various projects.
-- **Version Management**: Manage multiple versions of binaries efficiently and serve them up
-on request.
-- **Automated Compilation**: Future iterations will include automated compilation of binarie
-s from their source code, ensuring up-to-date versions are readily available.
-- **Event-Driven Updates**: Ultimately, the tool will be enhanced to compile binaries automa
-tically whenever new tags or releases are available in the source repositories.
+- **Static Binary Serving**: Initially, the server will serve static binary files, making it easy to access precompiled binaries for various projects.
+- **Version Management**: Manage multiple versions of binaries efficiently and serve them up on request.
+- **Automated Compilation**: Future iterations will include automated compilation of binaries from their source code, ensuring up-to-date versions are readily available.
+- **Event-Driven Updates**: Ultimately, the tool will be enhanced to compile binaries automatically whenever new tags or releases are available in the source repositories.
 
 ## Roadmap
 
 1. **Phase 1**: Serve static binary files
-   - [ ] During this phase, the server will be set up to serve binaries that are manually compil
-ed and placed in the designated directory.
+   - [ ] During this phase, the server will be set up to serve binaries that are manually compiled and placed in the designated directory.
 
 2. **Phase 2**: Automate Compilation
-   - [ ] Implement additional automation features to facilitate the compilation process, reducin
-g manual effort.
+   - [ ] Implement additional automation features to facilitate the compilation process, reducing manual effort.
 
 3. **Phase 3**: Event-Driven Compilation
-   - [ ] Integrate event-driven compilation that triggers builds based on updates in source repo
-sitories, ensuring all binaries are current and accessible.
+   - [ ] Integrate event-driven compilation that triggers builds based on updates in source repositories, ensuring all binaries are current and accessible.
 
 ## Dependencies
 
-Binary Dealer is built using [Axum](https://github.com/tokio-rs/axum) as its core dependency, which provides the foundationa
-l capabilities needed for the server functionality.
+Binary Dealer is built using [Axum](https://github.com/tokio-rs/axum) as its core dependency, which provides the foundational capabilities needed for the server functionality.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -46,20 +46,16 @@ To get started with Binary Dealer, follow these steps:
    git clone https://github.com/zingolabs/binary-dealer.git
    cd binary-dealer
    ```
+2. Generate or add your certs. We've used Let's Encrypt.
+   Customize your domain name with your certs by altering the source code in `src/main.rs` under `config = `.
+   Place your precompiled binaries in the specified directory for access.
 
-2. Build the project:
+3. Build the project:
    ```bash
    cargo build --release
  
-3. To enable TLS with a self-signed certificate and then return to the project's root folder:
-   ```bash
-   cd self_signed_certs
-   openssl req -newkey rsa:4096  -x509  -sha512  -days 500 -nodes -out cert.pem -keyout key.pem
-   cd ..
-
 4. Run the server:
    ```bash
    cargo run --release
    ```
 
-5. Place your precompiled binaries in the specified directory for access.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 
 ## Overview
 
-**Binary Dealer** is a Rust-based tool designed to streamline the distribution and management of static binary files across multiple projects. With an emphasis on version control and e
-ase of access, Binary Dealer aims to facilitate the seamless retrieval and deployment of binaries, while automating the build process as it evolves.
+**Binary Dealer** is a Rust-based tool designed to streamline the distribution and management of static binary files.
+With an emphasis on version control, Binary Dealer aims to facilitate the seamless retrieval and deployment of binaries.
+
+## Dependencies
+
+Binary Dealer is built using [Axum](https://github.com/tokio-rs/axum) as its core dependency, which provides the foundational capabilities needed for the server functionality.
+
+## Features
+- **Static Binary Serving**: The server will serve static files, making it easy to fetch precompiled binaries for various projects.
 
 ## Planned Features
 
-- **Static Binary Serving**: Initially, the server will serve static binary files, making it easy to access precompiled binaries for various projects.
 - **Version Management**: Manage multiple versions of binaries efficiently and serve them up on request.
 - **Automated Compilation**: Future iterations will include automated compilation of binaries from their source code, ensuring up-to-date versions are readily available.
 - **Event-Driven Updates**: Ultimately, the tool will be enhanced to compile binaries automatically whenever new tags or releases are available in the source repositories.
@@ -15,17 +21,13 @@ ase of access, Binary Dealer aims to facilitate the seamless retrieval and deplo
 ## Roadmap
 
 1. **Phase 1**: Serve static binary files
-   - [ ] During this phase, the server will be set up to serve binaries that are manually compiled and placed in the designated directory.
+   - [X] During this phase, the server will be set up to serve binaries that are manually compiled and placed in the designated directory.
 
 2. **Phase 2**: Automate Compilation
-   - [ ] Implement additional automation features to facilitate the compilation process, reducing manual effort.
+   - [ ] Implement additional automation features to facilitate the compilation process.
 
 3. **Phase 3**: Event-Driven Compilation
-   - [ ] Integrate event-driven compilation that triggers builds based on updates in source repositories, ensuring all binaries are current and accessible.
-
-## Dependencies
-
-Binary Dealer is built using [Axum](https://github.com/tokio-rs/axum) as its core dependency, which provides the foundational capabilities needed for the server functionality.
+   - [ ] Integrate event-driven compilation that triggers builds based on updates in source repositories, ensuring all binaries are current.
 
 ## Getting Started
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,10 +45,10 @@ async fn serve(app: Router, https_port: u16) {
 
     // configure let's encrypt CA certificate and private key used by https
     let config = RustlsConfig::from_pem_file(
-        PathBuf::from_str("/etc/letsencrypt/live/zingoproxy.com/")
+        PathBuf::from_str("/etc/letsencrypt/live/zingolabs.nexus/")
             .expect("to find letsencrypt dir")
             .join("fullchain.pem"),
-        PathBuf::from_str("/etc/letsencrypt/live/zingoproxy.com/")
+        PathBuf::from_str("/etc/letsencrypt/live/zingolabs.nexus/")
             .expect("to find letsencrypt dir")
             .join("privkey.pem"),
     )


### PR DESCRIPTION
This upgrades our core dependency to its most modern version, recently updated from 0.7.x to 0.8.x

this change is built on top of #20 - and is already deployed.